### PR TITLE
Fix expiration typo

### DIFF
--- a/app/client/stream.html
+++ b/app/client/stream.html
@@ -46,7 +46,7 @@
       <div class="col-md-10 col-sm-10 stream-data">
         <ul class="list-unstyled">
           <div>
-            Your funds will run out in <span am-time-ago="expirationDate"></span> ({{secondsLeft}} seconds)
+            Your funds will run out <span am-time-ago="expirationDate"></span> ({{secondsLeft}} seconds)
           </div>
         </ul>
       </div>


### PR DESCRIPTION
From my understanding, Moment.js automatically adds the word 'in' when describing future times ('in a minute', 'in four days'), which explains the current redundancy, e.g. 'Your funds will run out in in a minute (48 seconds)'.