### PR TITLE
Readme fixes and indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ with no counterparty risk.
 To run Streamium, just serve the root directory using any web server.
 For example:
 ```
-cd paystream/
+cd streamium/
 bower install
 python -m "SimpleHTTPServer"
 ```

--- a/app/provider/create.html
+++ b/app/provider/create.html
@@ -179,8 +179,8 @@
                 <div class="small-text-medium uppercase colored-text">
 
                 </div>
-                <h2 class="dark-text">Stream live video directly to your viewers and <strong>get paid instantly</strong>. No middlemen.</h2>
-                <div class="colored-line">
+                    <h2 class="dark-text">Stream live video directly to your viewers and <strong>get paid instantly</strong>. No middlemen.</h2>
+                    <div class="colored-line">
                 </div>
                 <div class="sub-heading">
                     
@@ -256,8 +256,8 @@
                 <div class="small-text-medium uppercase colored-text">
                     
                 </div>
-                <h2 class="dark-text">Just like Meerkat and Periscope, <strong>but with Bitcoin.</strong></h2>
-                <div class="colored-line">
+                    <h2 class="dark-text">Just like Meerkat and Periscope, <strong>but with Bitcoin.</strong></h2>
+                    <div class="colored-line">
                 </div>
                 <div class="sub-heading">
                    
@@ -408,10 +408,10 @@
                             <!-- ACORDIION HEADING / TITLE -->
                             <div class="panel-heading" id="headingOne">
                                 <h4 class="panel-title">
-                        <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
-                        <span class="icon-container color-bg"><span class="icon-ecommerce-dollar white-text"></span></span><span class="title-text">$0 Service Fees</span>
-                        </a>
-                        </h4>
+                                    <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+                                        <span class="icon-container color-bg"><span class="icon-ecommerce-dollar white-text"></span></span><span class="title-text">$0 Service Fees</span>
+                                    </a>
+                                </h4>
                             </div>
 
                             <!-- ACORDIION DESCRIPTION / TEXT -->
@@ -428,10 +428,10 @@
                             <!-- ACORDIION HEADING / TITLE -->
                             <div class="panel-heading" id="headingTwo">
                                 <h4 class="panel-title">
-                        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
-                        <span class="icon-container color-bg"><span class="icon-basic-lock white-text"></span></span><span class="title-text">Completely Private</span>
-                        </a>
-                        </h4>
+                                    <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+                                        <span class="icon-container color-bg"><span class="icon-basic-lock white-text"></span></span><span class="title-text">Completely Private</span>
+                                    </a>
+                                </h4>
                             </div>
 
                             <!-- ACORDIION DESCRIPTION / TEXT -->
@@ -448,10 +448,10 @@
                             <!-- ACORDIION HEADING / TITLE -->
                             <div class="panel-heading" id="headingThree">
                                 <h4 class="panel-title">
-                        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
-                        <span class="icon-container color-bg"><span class="icon-lightbulb-alt white-text"></span></span><span class="title-text">Get paid as you Stream</span>
-                        </a>
-                        </h4>
+                                    <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+                                        <span class="icon-container color-bg"><span class="icon-lightbulb-alt white-text"></span></span><span class="title-text">Get paid as you Stream</span>
+                                    </a>
+                                </h4>
                             </div>
 
                             <!-- ACORDIION DESCRIPTION / TEXT -->
@@ -544,9 +544,9 @@
                     <div class="small-text-medium uppercase colored-text">
                         
                     </div>
-                    <h2 class="white-text"><span class="strong white-text"></span>No need to install anything. It just works.</h2>
-                    <div class="colored-line">
-                    </div>
+                        <h2 class="white-text"><span class="strong white-text"></span>No need to install anything. It just works.</h2>
+                        <div class="colored-line">
+                        </div>
                     <div class="sub-heading white-text">
                         
                     </div>

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "Streamium",
   "description": "Decentralized trustless video streaming using bitcoin payment channels",
   "version": "0.0.0",
-  "homepage": "https://github.com/maraoz/streamium",
+  "homepage": "https://github.com/streamium/streamium",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "streamium",
   "description": "Decentralized trustless video streaming using bitcoin payment channels.",
   "version": "0.0.1",
-  "repository": "git://github.com/streamium/paystream",
+  "repository": "git://github.com/streamium/streamium",
   "license": "MIT",
   "keywords": [
     "video",


### PR DESCRIPTION
The readme file mentions the ```paystream``` folder when running the project for the first time.
I think this is an issue (may be other name of streamium) so removing it to the latest one.

Then there are indentation fixes.
