### PR TITLE
Fixed accordions in brief section at home page

### DIFF
--- a/app/provider/create.html
+++ b/app/provider/create.html
@@ -382,16 +382,16 @@
             <div class="row">
 
                 <!-- BRIEF IMAGE -->
-                <div class="col-md-6 "  >
+                <div class="col-md-6">
                     <div class="brief-image-left">
                         <img src="../assets/img/imac-ipad.png" alt="">
                     </div>
                 </div>
 
                 <!-- BRIEF HEADING -->
-                <div class="col-md-6 content-section "  >
+                <div class="col-md-6 content-section">
                     <div class="small-text-medium uppercase colored-text">
-                        
+
                     </div>
                     <h2 class="text-left dark-text">For<strong> Free</strong>. No Risks.</h2>
                     <div class="colored-line-left">
@@ -406,12 +406,10 @@
                         <div class="panel panel-default">
 
                             <!-- ACORDIION HEADING / TITLE -->
-                            <div class="panel-heading" id="headingOne">
+                            <div class="panel-heading" id="headingOne" data-toggle="collapse" data-parent="#accordion" data-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
                                 <h4 class="panel-title">
-                        <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
-                        <span class="icon-container color-bg"><span class="icon-ecommerce-dollar white-text"></span></span><span class="title-text">$0 Service Fees</span>
-                        </a>
-                        </h4>
+                                    <span class="icon-container color-bg"><span class="icon-ecommerce-dollar white-text"></span></span><span class="title-text">$0 Service Fees</span>
+                                </h4>
                             </div>
 
                             <!-- ACORDIION DESCRIPTION / TEXT -->
@@ -426,12 +424,10 @@
                         <div class="panel panel-default">
 
                             <!-- ACORDIION HEADING / TITLE -->
-                            <div class="panel-heading" id="headingTwo">
+                            <div class="panel-heading" id="headingTwo" data-toggle="collapse" data-parent="#accordion" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
                                 <h4 class="panel-title">
-                        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
-                        <span class="icon-container color-bg"><span class="icon-basic-lock white-text"></span></span><span class="title-text">Completely Private</span>
-                        </a>
-                        </h4>
+                                    <span class="icon-container color-bg"><span class="icon-basic-lock white-text"></span></span><span class="title-text">Completely Private</span>
+                                </h4>
                             </div>
 
                             <!-- ACORDIION DESCRIPTION / TEXT -->
@@ -446,12 +442,10 @@
                         <div class="panel panel-default">
 
                             <!-- ACORDIION HEADING / TITLE -->
-                            <div class="panel-heading" id="headingThree">
+                            <div class="panel-heading" id="headingThree" data-toggle="collapse" data-parent="#accordion" data-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
                                 <h4 class="panel-title">
-                        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
-                        <span class="icon-container color-bg"><span class="icon-lightbulb-alt white-text"></span></span><span class="title-text">Get paid as you Stream</span>
-                        </a>
-                        </h4>
+                                    <span class="icon-container color-bg"><span class="icon-lightbulb-alt white-text"></span></span><span class="title-text">Get paid as you Stream</span>
+                                </h4>
                             </div>
 
                             <!-- ACORDIION DESCRIPTION / TEXT -->

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -680,6 +680,14 @@ strong,
 	margin-top: 15px;
 }
 
+.brief .content-section .panel-group .panel-heading {
+    cursor: pointer;
+}
+
+.brief .content-section .panel-group .panel-heading:hover {
+    color: #008ed6;
+}
+
 .brief h2 {
 	margin-bottom: 15px;
 	margin-top: 10px;


### PR DESCRIPTION
Please note I've made the accordions to open by clicking on ANY section of the panel-heading of the accordion, there for removed the ```<a>``` tag and added the hover to make the text blue.
Fixes #110.