### PR TITLE
Automatically detect change address for consumer

### DIFF
--- a/app/client/controller.js
+++ b/app/client/controller.js
@@ -64,6 +64,14 @@ angular.module('streamium.client.controller', ['ngRoute'])
       for (utxo in utxos) {
         funds += utxos[utxo].satoshis;
       }
+      $.ajax({
+        url: config.BLOCKCYPHERTX + utxos[0].txId,
+        dataType: 'json'
+      }).done(function(transaction) {
+        $scope.client.change = transaction.inputs[0].addresses[0];
+        $scope.changeFromTransaction = $scope.client.change;
+        $scope.$apply();
+      });
       StreamiumClient.processFunding(utxos);
       $scope.funds = funds;
       $scope.fundedMillis = StreamiumClient.getDuration(funds);

--- a/app/client/join.html
+++ b/app/client/join.html
@@ -107,10 +107,10 @@
     <div class="col-sm-1 center step-count">3</div>
     <div class="col-sm-11 left-border">
       <div class="col-md-6">
-        When the stream ends, I want to receive my change at
+        When the stream ends, I want to receive my change at <span ng-show="client.change && changeFromTransaction === client.change">(detected from funding transaction)</span>
       </div>
-        <input type="text" name="change" ng-model="client.change"
-          placeholder="bitcoin change address" class="col-md-6 borderless" valid-address required>
+      <input type="text" name="change" ng-model="client.change"
+        placeholder="bitcoin change address" class="col-md-6 borderless" valid-address required>
     </div>
   </div>
 


### PR DESCRIPTION
When a transaction is received, the first input of the first UTXO for the funding address will be taken in as the change address