### PR TITLE
Adds conditional so that fromFiat isnt called when rate=0

### DIFF
--- a/app/provider/controller.js
+++ b/app/provider/controller.js
@@ -45,8 +45,10 @@ angular.module('streamium.provider.controller', ['ngRoute'])
   };
 
   $scope.usdHourToBtcSec = function(usdHour) {
-    var usdSecond = usdHour / 3600;
-    var btcSecond = bitcore.Unit.fromFiat(usdSecond, Rates.rate).toBTC();
+    if (Rates.rate) {
+      var usdSecond = usdHour / 3600;
+      var btcSecond = bitcore.Unit.fromFiat(usdSecond, Rates.rate).toBTC();
+    }
     return btcSecond ? btcSecond : 0;
   }
 


### PR DESCRIPTION
On load, [usdHourToBtcSec](https://github.com/streamium/streamium/blob/master/app/provider/controller.js#L47) is called multiple times, and Rates.rate is always 0 on the first call. This raises an error within bitcore.Unit.fromFiat. I've provided a screenshot from streamium.io .

I'm on OSX 10.9.5 & Chrome Version 43.0.2357.65 (64-bit).

![screen shot 2015-05-25 at 7 28 14 am](https://cloud.githubusercontent.com/assets/251807/7798514/ae7e900e-02af-11e5-81f3-3edd1c012b9e.png)